### PR TITLE
Make repository a generic linting document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Introduction
-ESLint is a tool to identify and report on patterns found in ECMAScript/JavaScript code, with the goal to make code more consistent and avoid bugs.
+Lint, or a linter, is a static code analysis tool used to flag programming errors, bugs, stylistic errors and suspicious constructs.
 
-This repository will document different technology specific linting rules for ESLint.
-
-At [Osmosys Software Solutions Pvt Ltd](https://osmosys.co/) we standardize the ESLint configuration, which will be used across multiple projects.
+This repository will document different technology specific linting configuration.
 
 # Technologies
 
@@ -13,6 +11,3 @@ At [Osmosys Software Solutions Pvt Ltd](https://osmosys.co/) we standardize the 
 - Node.js ([Nest.js](https://github.com/nestjs/nest))
 - Vue.js
 - Angular
-
-
-


### PR DESCRIPTION
**Summary**

- Instead of just documenting eslint specific configuration, we can make this repo more generic and all language configurations linters can be documented.
- Remove additional spaces from `README`